### PR TITLE
GraphQL infrastructure with first type and field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 **/*.js
 **/*.js.map
 **/*.db
+.*.sw*

--- a/package.json
+++ b/package.json
@@ -13,9 +13,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "graphql-yoga": "^1.16.2",
     "reflect-metadata": "^0.1.12",
     "sqlite3": "^4.0.2",
-    "typeorm": "^0.2.7"
+    "type-graphql": "^0.14.0",
+    "typedi": "^0.8.0",
+    "typeorm": "^0.2.7",
+    "typeorm-typedi-extensions": "^0.2.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.6",

--- a/src/entity/Course.ts
+++ b/src/entity/Course.ts
@@ -1,11 +1,15 @@
+import 'reflect-metadata';
+import {Field, ObjectType} from 'type-graphql';
 import {Column, Entity, OneToMany, PrimaryGeneratedColumn} from 'typeorm';
 import {Skill} from './Skill';
 
 @Entity()
+@ObjectType()
 export class Course {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Field()
   @Column()
   label: string;
 

--- a/src/resolver/Course.ts
+++ b/src/resolver/Course.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata';
+import { Resolver, Query } from 'type-graphql';
+import { Repository } from 'typeorm';
+import { InjectRepository } from 'typeorm-typedi-extensions';
+
+import { Course } from '../entity/Course';
+
+@Resolver(of => Course)
+export class CourseResolver {
+  constructor(
+    @InjectRepository(Course) private readonly courseRepository: Repository<Course>,
+  ) {}
+
+  @Query(returns => [Course])
+  courses(): Promise<Course[]> {
+    return this.courseRepository.find();
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "version": "2.4.2",
   "compilerOptions": {
-    "lib": ["es5", "es6"],
-    "target": "es6",
+    "lib": ["es5", "es6", "es2016", "esnext.asynciterable"],
+    "target": "es2016",
     "module": "commonjs",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Adds a GraphQL layer to the application. Now `npm run start` will start a GraphQL server at `http://localhost:4000/graphql` and a UI at `http://localhost:4000/playground`. In order to test, I implemented a first field, `courses`, which returns all courses, and just one field, `label`. Attached image shows it in action. Now it's matter of augmenting the schema, e.g., implement other types, their fields and mutations.
![graphql](https://user-images.githubusercontent.com/117518/46962573-dcdea880-d079-11e8-9742-683c467dd029.png)
